### PR TITLE
use Requires.jl to fix missing Gurobi import

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 JuMP
 MathProgBase
 Compat
+Requires 0.4.0

--- a/src/POD.jl
+++ b/src/POD.jl
@@ -8,7 +8,11 @@ using JuMP
 using MathProgBase
 using Compat
 
-PODDEBUG && using Gurobi
+using Requires: @require
+
+@require Gurobi begin
+    import Gurobi
+end
 
 include("const.jl")
 


### PR DESCRIPTION
Attempting to use POD.jl with Gurobi fails because there are several references to Gurobi in `utility.jl` but Gurobi.jl is never imported (unless you have PODDEBUG set). This is, essentially, exactly the case that  https://github.com/MikeInnes/Requires.jl is intended to resolve. Using `@require` only imports Gurobi into POD when the user does `import Gurobi` or `using Gurobi` in their own code (or if they have previously done so) and thus fixes the missing symbols without introducing a hard dependency. 

This should also hopefully become easier when Pkg3 lands in v0.7/1.0. 